### PR TITLE
bugfix for breaking editx plugin

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -2,7 +2,7 @@
 base   var
 author Gina Häußge, Michael Klier, Esther Brunner
 email  dokuwiki@chimeric.de
-date   2009-03-25
+date   2012-06-24
 name   Variable Plugin
 desc   Insert dynamic variables.
 url    http://www.dokuwiki.org/plugin:var

--- a/syntax.php
+++ b/syntax.php
@@ -5,13 +5,13 @@
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     Esther Brunner <wikidesign@gmail.com>
  */
- 
+
 // must be run within Dokuwiki
 if(!defined('DOKU_INC')) die();
 
 if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
 require_once(DOKU_PLUGIN.'syntax.php');
- 
+
 class syntax_plugin_var extends DokuWiki_Syntax_Plugin {
 
     function getType() { return 'substition'; }
@@ -21,7 +21,7 @@ class syntax_plugin_var extends DokuWiki_Syntax_Plugin {
     function handle($match, $state, $pos, &$handler) {
         $match = substr($match, 1, -1); // strip markup
         return array($match);
-    }            
+    }
 
     function render($mode, &$renderer, $data) {
         global $ID;
@@ -81,7 +81,8 @@ class syntax_plugin_var extends DokuWiki_Syntax_Plugin {
                 $nocache = true;
                 break;
             default:
-                $xhtml = $meta;
+                // for unknown match render original
+                $xhtml = "@{$meta}@";
                 break;
         }
 
@@ -101,4 +102,4 @@ class syntax_plugin_var extends DokuWiki_Syntax_Plugin {
         return false;
     }
 }
-// vim:ts=4:sw=4:et:enc=utf-8: 
+// vim:ts=4:sw=4:et:enc=utf-8:


### PR DESCRIPTION
this fixes problem with [editx](http://www.dokuwiki.org/plugin:editx) that it's `@LINK@` macro present in [lang/en/intro.txt](https://github.com/danny0838/dw-editx/blob/master/lang/en/intro.txt) does not get replaced
